### PR TITLE
Fix build with Java >7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ apply plugin: 'edu.sc.seis.launch4j'
 
 
 // Settings
-//sourceCompatibility = 1.7
+sourceCompatibility = 1.7
 targetCompatibility = 1.7
 
 


### PR DESCRIPTION
Hey! Thanks for your work!

Currently build fails with Java 8:
```
:compileJavajavacTask: target release 1.7 conflicts with default source release 1.8
```
Setting both compatibility parameters solves this.