### PR TITLE
Add methods to probe the size of the apk + splits on DownloadData

### DIFF
--- a/src/main/java/com/akdeniz/googleplaycrawler/DownloadData.java
+++ b/src/main/java/com/akdeniz/googleplaycrawler/DownloadData.java
@@ -112,6 +112,10 @@ public class DownloadData {
 			return ret;
 		}
 	}
+	
+	public long getAppSize() {
+		return appDeliveryData.getDownloadSize();	
+	}
 
 	/**
 	 * Query the total downloadsize
@@ -231,6 +235,13 @@ public class DownloadData {
 			return appDeliveryData.getSplitDeliveryData(n).getId();
 		}
 		return null;
+	}
+
+	public long getSplitSize(int n) {
+		if (getSplitCount() > 0) {
+			return appDeliveryData.getSplitDeliveryData(n).getDownloadSize();
+		}
+		return -1;
 	}
 
 }


### PR DESCRIPTION
My previous attempt for fiddle with DownloadData was too ambitious....
But it is good enough to be able to get the size of the main APK + splits