### PR TITLE
BUGFIX: ImportApp will continue to download

### DIFF
--- a/src/main/java/de/onyxbits/raccoon/gplay/ImportWorker.java
+++ b/src/main/java/de/onyxbits/raccoon/gplay/ImportWorker.java
@@ -54,6 +54,7 @@ class ImportWorker extends SwingWorker<List<BulkDetailsEntry>, Object> {
 		try {
 			List<BulkDetailsEntry> entries = get();
 			for (BulkDetailsEntry entry : entries) {
+				if (!entry.hasDoc()) continue; // Entry does not have doc ignore
 				doc = entry.getDoc();
 				globals.get(TransferManager.class).schedule(globals,
 						new AppDownloadWorker(globals, doc),TransferManager.WAN);


### PR DESCRIPTION
Previously if an app didn't have docs it would throw an exception and it would not add the rest to download list. 