### PR TITLE
Fix app order in DB query

### DIFF
--- a/src/main/java/de/onyxbits/raccoon/gplay/PlayAppOwnerDao.java
+++ b/src/main/java/de/onyxbits/raccoon/gplay/PlayAppOwnerDao.java
@@ -127,7 +127,7 @@ public class PlayAppOwnerDao extends DataAccessObject {
 
 		try {
 			st = c
-					.prepareStatement("SELECT aid, packagename, versioncode, mainversion, patchversion, name, version, minsdk FROM androidapps NATURAL JOIN playappownership WHERE pid = ? ORDER BY name, versioncode DESC");
+					.prepareStatement("SELECT aid, packagename, versioncode, mainversion, patchversion, name, version, minsdk FROM androidapps NATURAL JOIN playappownership WHERE pid = ? ORDER BY packagename, versioncode DESC");
 			st.setString(1, profile.getAlias());
 			st.execute();
 			res = st.getResultSet();


### PR DESCRIPTION
Incorrect ordering sometimes (app name changes) results in the latest version code not being returned first, as a result Raccoon downloads the same app every time Update is being invoked.