### PR TITLE
README reworked

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,22 +3,22 @@ Raccoon - PC APK Downloader
 
 Raccoon is an APK downloader for fetching apps from Google Play.
 
-* Cross platform (Linux, Windows, Mac OS)
-* Avoids the privacy issues that arise from connecting your Android device 
-  with a Google account
+* Cross platform (Linux, Windows, macOS)
+* Avoids the privacy issues arising from connecting your Android device 
+  with a Google account.
 * Easily install apps on multiple devices without downloading them several
   times.
 
 Building
 --------
 
-Raccoon is build with gradle. It is recommended to use the "launch4j" task
+Raccoon is built with Gradle. It is recommended to use the "launch4j" task
 instead of the standard one. Also, the version of the build must be submitted
-via the "version" property, e.g.:
+via the "version" property, e.g:
 
 gradlew -Pversion=4.x.y-DEV createExe
 
-Prebuild binaries are available at
+Prebuilt binaries are available at
 
 https://raccoon.onyxbits.de
 


### PR DESCRIPTION
I read https://raccoon.onyxbits.de/blog/reactions-bugreport-free-support/
and this was the best possible means of getting in contact.

> "guild tripping" in https://raccoon.onyxbits.de/blog/reactions-bugreport-free-support/'

should be "guilt tripping"

>If the license says, the software is free to use

should be

If the license says, "the software is free to use"

Off topic, → it could be that adding a support type culture could change the premise of doing it on a small scale.
If a community can fund features, and see that it is possible, the threshold of doing it is lowered.